### PR TITLE
Query bug when using union & ordering

### DIFF
--- a/test/ecto/integration/union_test.exs
+++ b/test/ecto/integration/union_test.exs
@@ -1,0 +1,42 @@
+defmodule Ecto.Integration.UnionTest do
+  use Ecto.Integration.Case
+  import Ecto.Query
+
+  alias Ecto.Integration.TestRepo
+  alias Ecto.Integration.Post
+
+  test "union & ordering" do
+    TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
+    TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
+
+    TestRepo.insert!(%Post{title: "bye", counter: 2, public: false})
+
+    other =
+      from(
+        p in Post,
+        where: p.public,
+        group_by: p.public,
+        order_by: fragment("total_counter"),
+        select: %{
+          public: p.public,
+          total_counter: sum(p.counter)
+        }
+      )
+
+    data =
+      from(
+        p in Post,
+        union_all: ^other,
+        where: not p.public,
+        group_by: p.public,
+        order_by: fragment("total_counter"),
+        select: %{
+          public: p.public,
+          total_counter: sum(p.counter)
+        }
+      )
+      |> TestRepo.all()
+
+    assert data == [%{public: false, total_counter: 2}, %{public: true, total_counter: 2}]
+  end
+end

--- a/test/ecto/integration/union_test.exs
+++ b/test/ecto/integration/union_test.exs
@@ -26,7 +26,6 @@ defmodule Ecto.Integration.UnionTest do
         union_all: ^other,
         where: not p.public,
         order_by: p.counter,
-        limit: 1,
         select: p.title
       )
       |> TestRepo.all()

--- a/test/ecto/integration/union_test.exs
+++ b/test/ecto/integration/union_test.exs
@@ -7,20 +7,17 @@ defmodule Ecto.Integration.UnionTest do
 
   test "union & ordering" do
     TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
-    TestRepo.insert!(%Post{title: "hello", counter: 1, public: true})
+    TestRepo.insert!(%Post{title: "morning", counter: 2, public: true})
 
-    TestRepo.insert!(%Post{title: "bye", counter: 2, public: false})
+    TestRepo.insert!(%Post{title: "bye", counter: 3, public: false})
 
     other =
       from(
         p in Post,
         where: p.public,
-        group_by: p.public,
-        order_by: fragment("total_counter"),
-        select: %{
-          public: p.public,
-          total_counter: sum(p.counter)
-        }
+        order_by: p.counter,
+        limit: 1,
+        select: p.title
       )
 
     data =
@@ -28,15 +25,12 @@ defmodule Ecto.Integration.UnionTest do
         p in Post,
         union_all: ^other,
         where: not p.public,
-        group_by: p.public,
-        order_by: fragment("total_counter"),
-        select: %{
-          public: p.public,
-          total_counter: sum(p.counter)
-        }
+        order_by: p.counter,
+        limit: 1,
+        select: p.title
       )
       |> TestRepo.all()
 
-    assert data == [%{public: false, total_counter: 2}, %{public: true, total_counter: 2}]
+    assert data == ["hello", "bye"]
   end
 end


### PR DESCRIPTION
The given test fails due to a wrong generation of the query.

The query generated is the following:
```sql
SELECT p0."title" 
FROM "posts" AS p0 
WHERE (NOT (p0."public")) 
UNION ALL SELECT p0."title" FROM "posts" AS p0 WHERE (p0."public") 
ORDER BY p0."counter" 
LIMIT 1 
ORDER BY p0."counter" 
LIMIT 1
```

The first order_by & limit should come before the union all.