### PR TITLE
Issue with custom decimal type

### DIFF
--- a/test/ecto/integration/custom_decimal_type.exs
+++ b/test/ecto/integration/custom_decimal_type.exs
@@ -1,0 +1,57 @@
+defmodule Ecto.Integration.CustomDecimalType do
+  use Ecto.Integration.Case
+
+  alias Ecto.Integration.TestRepo
+
+  alias __MODULE__.DecimalCaseTable
+
+  defmodule __MODULE__.Decimal18 do
+    use Ecto.ParameterizedType
+
+    @impl true
+    def type(type), do: {:parameterized, :ch, type}
+
+    @impl true
+    def init(opts) do
+      scale = Keyword.fetch!(opts, :scale)
+
+      (is_integer(scale) and scale >= 0) ||
+        raise ArgumentError, ":scale needs to be a non-negative integer"
+
+      {:decimal, 18, scale}
+    end
+
+    @impl true
+    def cast(value, _type), do: Ecto.Type.cast(:decimal, value)
+
+    @impl true
+    def dump(value, _dumper, _type), do: Ecto.Type.dump(:decimal, value)
+
+    @impl true
+    def load(value, _loader, _type), do: Ecto.Type.load(:decimal, value)
+  end
+
+  defmodule __MODULE__.DecimalCaseTable do
+    alias Ecto.Integration.CustomDecimalType.Decimal18
+
+    use Ecto.Schema
+
+    @primary_key false
+    schema "decimal_case_custom_type" do
+      field(:dec_field, Decimal18, scale: 4)
+    end
+  end
+
+  test "can encode custom Decimal18 type" do
+    raw_sql = """
+      CREATE TABLE if not exists decimal_case_custom_type (
+        dec_field Decimal(18, 4)
+      ) ENGINE = MergeTree
+      ORDER BY (dec_field)
+    """
+
+    {:ok, _} = Ecto.Adapters.SQL.query(TestRepo, raw_sql, [])
+
+    TestRepo.insert!(%DecimalCaseTable{dec_field: Decimal.new(5)})
+  end
+end


### PR DESCRIPTION
Hey,

me again 🙈 

I am not sure if I do something wrong but this fails with:

```
  1) test can encode custom Decimal18 type (Ecto.Integration.CustomDecimalType)
     test/ecto/integration/custom_decimal_type.exs:49
     ** (ArgumentError) errors were found at the given arguments:

       * 1st argument: not an iodata term

     code: TestRepo.insert!(%DecimalCaseTable{dec_field: Decimal.new(5)})
     stacktrace:
       (erts 13.1.4) :erlang.iolist_size([[["INSERT INTO ", [34, "decimal_case_custom_type", 34], 40, [[34, "dec_field", 34]], 41] | " FORMAT RowBinary"], 10, <<80, 195, 0::size(2)>>])
       (mint 1.5.1) lib/mint/http1.ex:1021: anonymous fn/1 in Mint.HTTP1.add_content_length_or_transfer_encoding/2
       (mint 1.5.1) lib/mint/core/util.ex:99: Mint.Core.Util.put_new_header_lazy/3
       (mint 1.5.1) lib/mint/http1.ex:1022: Mint.HTTP1.add_content_length_or_transfer_encoding/2
       (mint 1.5.1) lib/mint/http1.ex:268: Mint.HTTP1.request/5
       (ch 0.1.0) lib/ch/connection.ex:207: Ch.Connection.request/6
       (ch 0.1.0) lib/ch/connection.ex:140: Ch.Connection.handle_execute/4
       (db_connection 2.5.0) lib/db_connection/holder.ex:354: DBConnection.Holder.holder_apply/4
       (db_connection 2.5.0) lib/db_connection.ex:1432: DBConnection.run_execute/5
       (db_connection 2.5.0) lib/db_connection.ex:1527: DBConnection.run/6
       (db_connection 2.5.0) lib/db_connection.ex:713: DBConnection.execute/4
       (ch 0.1.0) lib/ch.ex:50: Ch.query/4
       (ecto_sql 3.10.1) lib/ecto/adapters/sql.ex:438: Ecto.Adapters.SQL.query!/4
       (chto 0.1.0) lib/ecto/adapters/clickhouse/schema.ex:47: Ecto.Adapters.ClickHouse.Schema.insert/4
       (ecto 3.10.1) lib/ecto/repo/schema.ex:764: Ecto.Repo.Schema.apply/4
       (ecto 3.10.1) lib/ecto/repo/schema.ex:377: anonymous fn/15 in Ecto.Repo.Schema.do_insert/4
       (ecto 3.10.1) lib/ecto/repo/schema.ex:273: Ecto.Repo.Schema.insert!/4
       test/ecto/integration/custom_decimal_type.exs:59: (test)
```

is this an encoding issue? 